### PR TITLE
Simple change to add ability to pass custom leftPaths to the file-man…

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -28,6 +28,10 @@ export default {
         let leftPath = response.data.config.leftPath;
         let rightPath = response.data.config.rightPath;
 
+        if(state.settings.overridePath) {
+          leftPath = state.settings.overridePath;
+        }
+
         // find disk and path settings in the URL
         if (window.location.search) {
           const params = new URLSearchParams(window.location.search);

--- a/src/store/settings/getters.js
+++ b/src/store/settings/getters.js
@@ -25,4 +25,13 @@ export default {
   authHeader(state) {
     return Object.prototype.hasOwnProperty.call(state.headers, 'Authorization');
   },
+
+  /**
+   * Override Path
+   * @param state
+   * @returns {string|null}
+   */
+  overridePath(state) {
+    return state.overridePath;
+  },
 };

--- a/src/store/settings/mutations.js
+++ b/src/store/settings/mutations.js
@@ -27,6 +27,10 @@ export default {
     if (Object.prototype.hasOwnProperty.call(data, 'translation')) {
       Vue.set(state.translations, data.translation.name, Object.freeze(data.translation.content));
     }
+    // override path
+    if (Object.prototype.hasOwnProperty.call(data, 'overridePath')) {
+      state.overridePath = data.overridePath;
+    }
   },
 
   /**

--- a/src/store/settings/store.js
+++ b/src/store/settings/store.js
@@ -191,6 +191,9 @@ export default {
         yaml: 'text/x-yaml',
         json: 'application/json',
       },
+
+      // Override Path
+      overridePath: null
     };
   },
   mutations,


### PR DESCRIPTION
Simple change to add ability to pass custom leftPaths to the file-manager component to allow for dynamic directories for customization.

`<file-manager v-bind:settings="{ overridePath: '/my/custom/path }"></file-manager>`

Could also clarify left vs. right path in a later update.