### PR TITLE
Fix modal with Bootstrap 5

### DIFF
--- a/src/components/modals/ModalBlock.vue
+++ b/src/components/modals/ModalBlock.vue
@@ -1,6 +1,6 @@
 <template>
     <transition name="fm-modal">
-        <div class="fm-modal" ref="fmModal" v-on:click="hideModal">
+        <div class="modal fm-modal" ref="fmModal" v-on:click="hideModal">
             <div class="modal-dialog" role="document" v-bind:class="modalSize" v-on:click.stop>
                 <component v-bind:is="modalName" />
             </div>


### PR DESCRIPTION
The `<div class="fm-modal">` you are injecting is missing the bootstrap 5 class modal, so it should become:
`<div class="modal fm-modal">`.

Can you please merge this pull request? your file-manager is not usable as it is for the moment.
Please also update https://github.com/alexusmai/laravel-file-manager ! 
Thanks a lot!

