### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -134,7 +134,7 @@
         "@vue/shared": "3.2.37",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
-        "postcss": "^8.1.10",
+        "postcss": "^8.4.14",
         "source-map": "^0.6.1"
       }
     },


### PR DESCRIPTION
Affected versions of this package are vulnerable to Improper Input Validation when parsing external Cascading Style Sheets (CSS) with linters using PostCSS. An attacker can cause discrepancies by injecting malicious CSS rules, such as @font-face{ font:(\r/*);}. This vulnerability is because of an insecure regular expression usage in the RE_BAD_BRACKET variable.

the one in this file was outdated